### PR TITLE
Adds openapi file

### DIFF
--- a/validator/openapi.json
+++ b/validator/openapi.json
@@ -1,0 +1,144 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "description": "This is the SpaceApi Validator api",
+    "version": "0.0.1",
+    "title": "SpaceApi Validator"
+  },
+  "servers": [
+    {
+      "url": "https://validator.spaceapi.io",
+      "description": "The SpaceApi Validator Service"
+    }
+  ],
+  "paths": {
+    "/v1/": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "responses": {
+          "200": {
+            "description": "get default information about the server",
+            "content": {
+              "application/json": {
+                "schema": {
+
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/validate/": {
+      "post": {
+        "tags": [
+          "v1"
+        ],
+        "summary": "validate an input against the SpaceApi schema",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ValidationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ValidationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "request body is malformed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "path doesn't exist",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "something went wrong"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ValidationRequest": {
+        "properties": {
+          "data": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "ValidationResponse": {
+        "properties": {
+          "valid": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "valid",
+          "message"
+        ]
+      },
+      "ServerInformation": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "usage": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "description",
+          "usage",
+          "version"
+        ]
+      },
+      "ValidationError": {
+        "properties": {
+          "details": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "details"
+        ]
+      }
+    }
+  }
+}
+

--- a/validator/server.py
+++ b/validator/server.py
@@ -7,7 +7,7 @@ except ImportError:
 import os
 
 import bottle
-from bottle import request, response, redirect, abort, error
+from bottle import request, response, redirect, abort, error, static_file
 from jsonschema.exceptions import SchemaError
 
 import validation
@@ -82,6 +82,11 @@ def invalid_payload(message: str) -> dict:
 @app.route('/', method=['GET', 'OPTIONS'])
 def root():
     redirect('/v1/')
+
+
+@app.route("/openapi.json", method=['GET', 'OPTIONS'])
+def openapi():
+    return static_file("openapi.json", root="./")
 
 
 @app.route('/v1/', method=['GET', 'OPTIONS'])


### PR DESCRIPTION
This adds the current implementation of the api. 

Unfortunately there is a bug inside the validator so the swagger UI doesn't work well. And breaks if you try to validate a schema. A comparable curl would be 
```bash
curl https://validator.spaceapi.io/v1/validate/ -H 'Content-Type: application/json' --data '{"data":{"api":"0.13"}}'
```
I wouldn't fix it right now since we discussed switching to a different implementation and no one is using the swagger UI anyways.