### PR TITLE
Fix /v1 and /v2 call

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,13 @@ func main() {
 	root.HandleFunc(pat.Get("/"), versionRedirect)
 	root.HandleFunc(pat.Get("/openapi.json"), openAPI)
 
+	root.HandleFunc(pat.Get("/v1"), func (writer http.ResponseWriter, request *http.Request) {
+		http.Redirect(writer, request, "/v1/", 302)
+	})
+	root.HandleFunc(pat.Get("/v2"), func (writer http.ResponseWriter, request *http.Request) {
+		http.Redirect(writer, request, "/v2/", 302)
+	})
+
 	root.Handle(pat.New("/v1/*"), v1.GetSubMux())
 	root.Handle(pat.New("/v2/*"), v2.GetSubMux())
 

--- a/openapi.go
+++ b/openapi.go
@@ -33,7 +33,7 @@ var openapi = `{
         }
       }
     },
-    "/v1/validate": {
+    "/v1/validate/": {
       "post": {
         "tags": [
           "v1"


### PR DESCRIPTION
Adds forwardings for subrouters, set /v1/validate/ as the default route in openapi