### PR TITLE
Raise limiter to over directory size

### DIFF
--- a/v2/validator.go
+++ b/v2/validator.go
@@ -56,7 +56,7 @@ func GetSubMux() *goji.Mux {
 		pat.Post("/validateURL"),
 		limit(
 			http.HandlerFunc(validateURL),
-			rate.NewLimiter(10, 25),
+			rate.NewLimiter(200, 500),
 		),
 	)
 

--- a/v2/validator.go
+++ b/v2/validator.go
@@ -56,7 +56,7 @@ func GetSubMux() *goji.Mux {
 		pat.Post("/validateURL"),
 		limit(
 			http.HandlerFunc(validateURL),
-			rate.NewLimiter(200, 500),
+			rate.NewLimiter(200, 500), // (rate, burst)
 		),
 	)
 


### PR DESCRIPTION
parallelizing calls for rebuilding the directory leads to problems, raising this to a number larger then the directory size should fix it