### PR TITLE
Close connection from checked url

### DIFF
--- a/v2/validator.go
+++ b/v2/validator.go
@@ -198,6 +198,12 @@ func fetchURL(validationResponse *urlValidationResponse, url *url.URL, skipVerif
 		validationResponse.Reachable = false
 		return nil, "", nil
 	}
+	defer func() {
+		err := response.Body.Close()
+		if err != nil {
+			panic(err)
+		}
+	}()
 
 	if response.StatusCode >= 400 {
 		validationResponse.Reachable = false


### PR DESCRIPTION
Metrics report a connection leak, it's probably this one (forgot to close the connection after checking the url).