### PR TITLE
Fix swagger and checked version field notation

### DIFF
--- a/openapi.go
+++ b/openapi.go
@@ -247,6 +247,12 @@ var openapi = `{
           "certValid": {
             "type": "boolean"
           },
+          "checkedVersions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "validatedJson": {
             "type": "object"
           },
@@ -274,6 +280,12 @@ var openapi = `{
           },
           "message": {
             "type": "string"
+          },          
+          "checkedVersions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "validatedJson": {
             "type": "object"

--- a/v2/validator.go
+++ b/v2/validator.go
@@ -33,7 +33,7 @@ type urlValidationResponse struct {
 	Cors          	bool          `json:"cors"`
 	ContentType   	bool          `json:"contentType"`
 	CertValid     	bool          `json:"certValid"`
-	CheckedVersions	[]string	`json:"checked_versions,omitempty"`
+	CheckedVersions	[]string      `json:"checkedVersions,omitempty"`
 	ValidatedJson 	interface{}   `json:"validatedJson,omitempty"`
 	SchemaErrors  	[]schemaError `json:"schemaErrors,omitempty"`
 }
@@ -46,7 +46,7 @@ type schemaError struct {
 type jsonValidationResponse struct {
 	Valid         bool          `json:"valid"`
 	Message       string        `json:"message"`
-	CheckedVersions	[]string	`json:"checked_versions,omitempty"`
+	CheckedVersions	[]string	`json:"checkedVersions,omitempty"`
 	ValidatedJson interface{}   `json:"validatedJson,omitempty"`
 	SchemaErrors  []schemaError `json:"schemaErrors,omitempty"`
 }


### PR DESCRIPTION
Forgot to add the checked version field to swagger, also used an underscore where the rest of the fields use camel case notation