### PR TITLE
Fix connection leak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,12 @@ RUN go install  ./...
 
 
 FROM alpine:latest
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates curl
 WORKDIR /app
 COPY --from=builder /go/bin/validator /usr/local/bin/validator
 EXPOSE 8080
+
+HEALTHCHECK --start-period=5s CMD curl --fail http://localhost:8080/v1/ || exit 1
 
 RUN adduser app -S -u 142
 USER app


### PR DESCRIPTION
I've found the leak, apparently the http client does not close idle connection by itself (not even if the scope is left). 
And since we have to instantiate on every check it caught us big time.