### PR TITLE
Upgrade go-spaceapi-validator: 0.0.6 → 0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/rs/cors v1.7.0
-	github.com/spaceapi-community/go-spaceapi-validator v0.0.6
+	github.com/spaceapi-community/go-spaceapi-validator v0.2.0
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	goji.io v2.0.2+incompatible
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
-github.com/spaceapi-community/go-spaceapi-validator v0.0.6 h1:NDBCK6TAHystX1U2DuCruOiJFFOeLRWOIiZnv3f30z8=
-github.com/spaceapi-community/go-spaceapi-validator v0.0.6/go.mod h1:QwRul/7SjshUowS6hZsh+T9WOOpR+NAQGSc0kesyIZY=
+github.com/spaceapi-community/go-spaceapi-validator v0.2.0 h1:Um+nDKIRhA7zhuxU3LQ28y4gFwLFn+wJ8MBofovfj2Q=
+github.com/spaceapi-community/go-spaceapi-validator v0.2.0/go.mod h1:QwRul/7SjshUowS6hZsh+T9WOOpR+NAQGSc0kesyIZY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
I ran:

    go get github.com/spaceapi-community/go-spaceapi-validator@v0.2.0
    go mod tidy

...to update the library.

I then ran `go run ./...` and tested the validator:

    cat luxeria.json | http post http://localhost:8080/v2/validateJSON

...which worked!

```json
{
    "checkedVersions": [
        "15"
    ],
    "message": "",
    "valid": true,
...
```